### PR TITLE
keccak256 has been removed from the standard library in Noir 1.0.0-beta.4+.

### DIFF
--- a/circuits/Nargo.toml
+++ b/circuits/Nargo.toml
@@ -4,5 +4,5 @@ type = "bin"
 authors = ["Ciara Nightingale"]
 
 [dependencies]
-ecrecover = { tag = "v0.30.0", git = "https://github.com/colinnielsen/ecrecover-noir" }
+ecrecover = { tag = "v1.0.0", git = "https://github.com/colinnielsen/ecrecover-noir" }
 keccak256 = { git = "https://github.com/noir-lang/keccak256", tag = "v0.1.0" }

--- a/circuits/Nargo.toml
+++ b/circuits/Nargo.toml
@@ -5,3 +5,4 @@ authors = ["Ciara Nightingale"]
 
 [dependencies]
 ecrecover = { tag = "v0.30.0", git = "https://github.com/colinnielsen/ecrecover-noir" }
+keccak256 = { git = "https://github.com/noir-lang/keccak256", tag = "v0.1.0" }


### PR DESCRIPTION
In Noir versions >= 1.0.0-beta.4, the `keccak256` function has been removed from the standard library (`std::hash::keccak256`) and moved into its own dedicated external crate: [`keccak256`](https://github.com/noir-lang/keccak256).

This PR addresses the following:
- Adds the external `keccak256` crate as a project dependency
- Updates the `ecrecover` dependency to version `v1.0.0` which reflects this change internally

These updates are required to maintain compatibility with the latest Noir compiler and ecosystem.

### Why this is needed
Projects using the old standard library path for `keccak256` will fail to compile or run in recent Noir versions, making this a necessary fix for forward compatibility.

---

Multiple users are currently facing this issue

https://discord.com/channels/1127263608246636635/1226257559669837896/1398910286026772500